### PR TITLE
Fix connect for empty hostname

### DIFF
--- a/ui/hosts.go
+++ b/ui/hosts.go
@@ -105,8 +105,11 @@ func NewHostsTable(app *tview.Application, sshConfigPath string, filter string, 
 			row, _ := table.GetSelection()
 			hostname := table.GetCell(row, 0).Text
 
-			app.Stop()
-			connect(hostname, sshConfigPath)
+			// In case no host is selected
+			if len(hostname) > 0 {
+				app.Stop()
+				connect(hostname, sshConfigPath)
+			}
 		}
 
 		return event


### PR DESCRIPTION
Added check for empty hostname that wraps the SSH connect call #12 

Actually, I thought that `table.GetSelection()` would return -1 or some error-like result, but it returns the 1st row (suppose it returns the last row selected). Hope this helps a bit at least 😃 