### PR TITLE
Flake-y fixes and tweaks

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "flake-utils": {
       "locked": {
-        "lastModified": 1649676176,
-        "narHash": "sha256-OWKJratjt2RW151VUlJPRALb7OU2S5s+f0vLj4o1bHM=",
+        "lastModified": 1656928814,
+        "narHash": "sha256-RIFfgBuKz6Hp89yRr7+NR5tzIAbn52h8vT6vXkYjZoM=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "a4b154ebbdc88c8498a5c7b01589addc9e9cb678",
+        "rev": "7e2a3b3dfd9af950a856d66b0a7d01e3c18aa249",
         "type": "github"
       },
       "original": {
@@ -17,11 +17,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1650161686,
-        "narHash": "sha256-70ZWAlOQ9nAZ08OU6WY7n4Ij2kOO199dLfNlvO/+pf8=",
+        "lastModified": 1657356697,
+        "narHash": "sha256-sT38tcx7m0Quz+Uj6jzx+yRa2+EVW2C3cE0FkROXUzQ=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "1ffba9f2f683063c2b14c9f4d12c55ad5f4ed887",
+        "rev": "87e7965bbcdbac3d103e3ed14ff04f719a4f7a58",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -20,7 +20,7 @@
           pname = "sshs";
           inherit version;
           src = ./.;
-          ldflags = [ "-s" "-w" "-X github.com/quantumsheep/sshs/cmd.Version=${version}" ];
+          ldflags = ["-s" "-w" "-X github.com/quantumsheep/sshs/cmd.Version=${version}"];
           vendorSha256 = "wClgX08UbItCpWOkWLgmsy7Ad5LlpvXrStN3JHujVww=";
         };
       }

--- a/flake.nix
+++ b/flake.nix
@@ -1,24 +1,27 @@
 {
   description = "Terminal user interface for SSH";
-  
+
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
     flake-utils.url = "github:numtide/flake-utils";
   };
 
-  outputs = { self, nixpkgs, flake-utils }:
-  flake-utils.lib.eachDefaultSystem (system:
-  let
-    version = builtins.substring 0 8 self.lastModifiedDate;
-    pkgs = nixpkgs.legacyPackages.${system};
-  in
-    rec {
-      defaultPackage = pkgs.buildGoModule {
-        pname = "sshs";
-        inherit version;
-        src = ./.;
-        vendorSha256 = "QWFz85bOrTnPGum5atccB5hKeATlZvDAt32by+DO/Fo=";
-      };
-    }
-  );
+  outputs = {
+    self,
+    nixpkgs,
+    flake-utils,
+  }:
+    flake-utils.lib.eachDefaultSystem (
+      system: let
+        version = "3.2.0-" + (self.shortRev or "dirty");
+        pkgs = nixpkgs.legacyPackages.${system};
+      in rec {
+        packages.default = pkgs.buildGoModule {
+          pname = "sshs";
+          inherit version;
+          src = ./.;
+          vendorSha256 = "wClgX08UbItCpWOkWLgmsy7Ad5LlpvXrStN3JHujVww=";
+        };
+      }
+    );
 }

--- a/flake.nix
+++ b/flake.nix
@@ -13,13 +13,14 @@
   }:
     flake-utils.lib.eachDefaultSystem (
       system: let
-        version = "3.2.0-" + (self.shortRev or "dirty");
+        version = "3.2.0" + "-" + (self.shortRev or "dirty");
         pkgs = nixpkgs.legacyPackages.${system};
       in rec {
         packages.default = pkgs.buildGoModule {
           pname = "sshs";
           inherit version;
           src = ./.;
+          ldflags = [ "-s" "-w" "-X github.com/quantumsheep/sshs/cmd.Version=${version}" ];
           vendorSha256 = "wClgX08UbItCpWOkWLgmsy7Ad5LlpvXrStN3JHujVww=";
         };
       }


### PR DESCRIPTION
## Just some nix flake related tweaks and fixes :)

### Specifically:
- Flake version is now 3.2.0-dirty if the git repository is dirty (Has uncommitted changes)
  otherwise, version is formatted as 3.2.0-hash (Hash being the latest commit hash in short form)
  - For example, `sshs-3.2.0-dirty`, or `sshs-3.2.0-1f93fbd`
- Updated the Flake lockfile, and in turn also updated the hash in `flake.nix`
- Formatted the Flake with the commonly-used `Alejandra` nix formatter
- Added the same LDFLAGS to the flake's build instructions as are present in the `Makefile`

Let me know if anything doesn't look right or needs changing!