### PR TITLE
Updated Nix installation instructions in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,12 +44,19 @@ yay -Syua --needed --noconfirm sshs
 
 ## NixOS / Nix
 NixOS config and Home Manager config might not work yet on non-unstable channels (PR [#181901](https://github.com/NixOS/nixpkgs/pull/181901))
+
+### As a Flake
 ```shell
-# As a Flake
 nix profile install 'github:quantumsheep/sshs'
-# In your NixOS configuration
+```
+
+### In your NixOS configuration
+```nix
 environment.systemPackages = with pkgs; [ sshs ];
-# In your Home Manager configuration
+```
+
+### In your Home Manager configuration
+```nix
 home.packages = with pkgs; [ sshs ];
 ```
 

--- a/README.md
+++ b/README.md
@@ -42,9 +42,15 @@ makepkg -si
 yay -Syua --needed --noconfirm sshs
 ```
 
-## NixOS / Nix (with flakes enabled)
+## NixOS / Nix
+NixOS config and Home Manager config might not work yet on non-unstable channels (PR [#181901](https://github.com/NixOS/nixpkgs/pull/181901))
 ```shell
+# As a Flake
 nix profile install 'github:quantumsheep/sshs'
+# In your NixOS configuration
+environment.systemPackages = with pkgs; [ sshs ];
+# In your Home Manager configuration
+home.packages = with pkgs; [ sshs ];
 ```
 
 ## From releases


### PR DESCRIPTION
- Updated README.md to reflect new Nix / NixOS installation instructions
  - Also noted that instructions might not work yet unless user is on the `unstable` branch, this warning can be removed once nixpkgs backport PR [#181901](https://github.com/NixOS/nixpkgs/pull/181901) is merged