### PR TITLE
Add new option

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -71,13 +71,18 @@ func run(cmd *cobra.Command, args []string) {
 		exitAfterSession = exitFlag
 	}
 
+	sshArguments := ""
+	if ssh_argumentsFlag, e := flags.GetString("ssh-arguments"); e == nil {
+		sshArguments = ssh_argumentsFlag
+	}
+
 	table := ui.NewHostsTable(app, ui.HostsTableOptions{
 		SSHConfigPath:          absoluteSshConfigPath,
 		Filter:                 filter,
 		ShouldSortByName:       sortByName,
 		ShouldDisplayFullProxy: displayFullProxy,
 		ShouldExitAfterSession: exitAfterSession,
-	})
+	}, sshArguments)
 
 	searchBar := ui.NewSearchBar(filter)
 
@@ -121,6 +126,7 @@ func Execute() {
 
 func init() {
 	flags := rootCmd.PersistentFlags()
+	flags.StringP("ssh-arguments", "a", "", "Arguments for the ssh command (example: '-D 1080'")
 	flags.StringP("search", "s", "", "Host search filter")
 	flags.StringP("config", "c", "~/.ssh/config", "SSH config file")
 	flags.BoolP("proxy", "p", false, "Display full ProxyCommand")

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.18
 require (
 	github.com/asaskevich/govalidator v0.0.0-20210307081110-f21760c49a8d
 	github.com/gdamore/tcell/v2 v2.5.3
+	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
 	github.com/mikkeloscar/sshconfig v0.1.1
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/rivo/tview v0.0.0-20221029100920-c4a7e501810d

--- a/go.sum
+++ b/go.sum
@@ -119,6 +119,8 @@ github.com/google/pprof v0.0.0-20201023163331-3e6fc7fc9c4c/go.mod h1:kpwsk12EmLe
 github.com/google/pprof v0.0.0-20201203190320-1bf35d6f28c2/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/pprof v0.0.0-20201218002935-b9804c9f04c2/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
+github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 h1:El6M4kTTCOh6aBiKaUGG7oYTSPP8MxqL4YI3kZKwcP4=
+github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3pAXIBCelhxNneeOaAeabZDe5s4K6zSpQ=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=


### PR DESCRIPTION
Add the option `-a`, `--ssh-arguments` to directly pass arguments to the ssh command.
I personally use this option mostly for port forwarding or configuring a ssh proxy socks.