### PR TITLE
Update install instructions with the official Arch Linux package

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,22 +34,8 @@ choco install sshs
 
 ### Arch Linux
 
-#### Pacman
-
-[Vote for the package to be added to the official repository](https://aur.archlinux.org/packages/sshs).  
-In the meantime you can manually install it by cloning the repository and running `makepkg`:
-
 ```shell
-pacman -S --needed git base-devel
-git clone https://aur.archlinux.org/sshs.git
-cd sshs
-makepkg -si
-```
-
-#### Yay
-
-```shell
-yay -Syua --needed --noconfirm sshs
+pacman -S sshs
 ```
 
 ### NixOS / Nix


### PR DESCRIPTION
sshs is now available in the [official Arch Linux [extra] repository](https://archlinux.org/packages/extra/x86_64/sshs/) :)