### PR TITLE
feat(ui): add CTRL+N and ctrl+P keybinds

### DIFF
--- a/src/ui.rs
+++ b/src/ui.rs
@@ -253,19 +253,11 @@ impl App {
 
         match key.code {
             Char('c') => AppKeyAction::Stop,
-            Char('j') => {
+            Char('j' | 'n') => {
                 self.next();
                 AppKeyAction::Ok
             }
-            Char('k') => {
-                self.previous();
-                AppKeyAction::Ok
-            }
-            Char('n') => {
-                self.next();
-                AppKeyAction::Ok
-            }
-            Char('p') => {
+            Char('k' | 'p') => {
                 self.previous();
                 AppKeyAction::Ok
             }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -261,6 +261,14 @@ impl App {
                 self.previous();
                 AppKeyAction::Ok
             }
+            Char('n') => {
+                self.next();
+                AppKeyAction::Ok
+            }
+            Char('p') => {
+                self.previous();
+                AppKeyAction::Ok
+            }
             _ => AppKeyAction::Continue,
         }
     }


### PR DESCRIPTION
Using (neo)vim in combination with tmux conflicts with the keybindings ctrl+j and ctrl+k.
The aforementioned bindings are used to move between panes. 
ctrl+n and ctrl+p is used in (neo)vim to move to the next end previous match, which would also make sense in this case.

This PR with https://github.com/quantumsheep/sshs/issues/54 closes https://github.com/quantumsheep/sshs/issues/110