### PR TITLE
chore: bump version to 4.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -708,7 +708,7 @@ checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "sshs"
-version = "4.5.1"
+version = "4.6.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sshs"
-version = "4.5.1"
+version = "4.6.0"
 edition = "2021"
 description = "Terminal user interface for SSH"
 license = "MIT"


### PR DESCRIPTION
bump version to 4.6.0

- https://github.com/Homebrew/homebrew-core/pull/205065

cc @quantumsheep 