### PR TITLE
fix: patch version to match with the release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -907,7 +907,7 @@ checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "sshs"
-version = "4.6.1"
+version = "4.7.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -907,7 +907,7 @@ checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "sshs"
-version = "4.7.1"
+version = "4.7.2"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sshs"
-version = "4.7.1"
+version = "4.7.2"
 edition = "2021"
 description = "Terminal user interface for SSH"
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sshs"
-version = "4.6.1"
+version = "4.7.1"
 edition = "2021"
 description = "Terminal user interface for SSH"
 license = "MIT"


### PR DESCRIPTION
patch version to match with the 4.7.1 rel

relates to https://github.com/Homebrew/homebrew-core/pull/220842