### PR TITLE
Return entered text if no matches

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -34,6 +34,10 @@ struct Args {
     #[arg(long, default_value_t = true)]
     sort: bool,
 
+    /// Fancy Levenshtein sort by edit distance
+    #[arg(long, default_value_t = false)]
+    sort_fancy: bool,
+
     /// Handlebars template of the command to execute
     #[arg(short, long, default_value = "ssh \"{{{name}}}\"")]
     template: String,
@@ -58,6 +62,7 @@ fn main() -> Result<()> {
         config_paths: args.config,
         search_filter: args.search,
         sort_by_name: args.sort,
+        sort_by_levenshtein: args.sort_fancy,
         show_proxy_command: args.show_proxy_command,
         command_template: args.template,
         command_template_on_session_start: args.on_session_start_template,

--- a/src/searchable.rs
+++ b/src/searchable.rs
@@ -1,25 +1,33 @@
+use fuzzy_matcher::FuzzyMatcher;
+use fuzzy_matcher::skim::SkimMatcherV2;
+
 type SearchableFn<T> = dyn FnMut(&&T, &str) -> bool;
+
+pub trait SearchableItem {
+    fn search_text(&self) -> &str;
+}
 
 pub struct Searchable<T>
 where
-    T: Clone,
+    T: Clone + SearchableItem,
 {
+    sort_by_levenshtein: bool,
     vec: Vec<T>,
-
     filter: Box<SearchableFn<T>>,
     filtered: Vec<T>,
 }
 
 impl<T> Searchable<T>
 where
-    T: Clone,
+    T: Clone + SearchableItem,
 {
     #[must_use]
-    pub fn new<P>(vec: Vec<T>, search_value: &str, predicate: P) -> Self
+    pub fn new<P>(sort_by_levenshtein: bool, vec: Vec<T>, search_value: &str, predicate: P) -> Self
     where
         P: FnMut(&&T, &str) -> bool + 'static,
     {
         let mut searchable = Self {
+            sort_by_levenshtein,
             vec,
 
             filter: Box::new(predicate),
@@ -35,12 +43,30 @@ where
             return;
         }
 
-        self.filtered = self
+        if self.sort_by_levenshtein {
+            let matcher = SkimMatcherV2::default();
+            let mut items: Vec<_> = self
+                .vec
+                .iter()
+                .filter(|host| (self.filter)(host, value))
+                .map(|item| {
+                    let score = matcher.fuzzy_match(item.search_text(), value).unwrap_or(0);
+                    (item.clone(), score)
+                })
+                .collect();
+
+            // Sort by Levenshtein distance in descending order (higher score = better match)
+            items.sort_by(|a, b| b.1.cmp(&a.1));
+
+            self.filtered = items.into_iter().map(|(item, _)| item).collect();
+        } else {
+            self.filtered = self
             .vec
             .iter()
             .filter(|host| (self.filter)(host, value))
             .cloned()
             .collect();
+        }
     }
 
     #[allow(clippy::must_use_candidate)]
@@ -64,7 +90,7 @@ where
 
 impl<'a, T> IntoIterator for &'a Searchable<T>
 where
-    T: Clone,
+    T: Clone + SearchableItem,
 {
     type Item = &'a T;
     type IntoIter = std::slice::Iter<'a, T>;
@@ -76,7 +102,7 @@ where
 
 impl<T> std::ops::Index<usize> for Searchable<T>
 where
-    T: Clone,
+    T: Clone + SearchableItem,
 {
     type Output = T;
 

--- a/src/searchable.rs
+++ b/src/searchable.rs
@@ -13,6 +13,7 @@ where
 {
     sort_by_levenshtein: bool,
     vec: Vec<T>,
+    matcher: SkimMatcherV2,
     filter: Box<SearchableFn<T>>,
     filtered: Vec<T>,
 }
@@ -29,7 +30,7 @@ where
         let mut searchable = Self {
             sort_by_levenshtein,
             vec,
-
+            matcher: SkimMatcherV2::default(),
             filter: Box::new(predicate),
             filtered: Vec::new(),
         };
@@ -43,13 +44,12 @@ where
             return;
         }
 
-        let matcher = SkimMatcherV2::default();
         let mut items: Vec<_> = self
             .vec
             .iter()
             .filter(|host| (self.filter)(host, value))
             .map(|item| {
-                let score = matcher.fuzzy_match(item.search_text(), value).unwrap_or(0);
+                let score = self.matcher.fuzzy_match(item.search_text(), value).unwrap_or(0);
                 (item.clone(), score)
             })
             .collect();

--- a/src/searchable.rs
+++ b/src/searchable.rs
@@ -5,6 +5,7 @@ type SearchableFn<T> = dyn FnMut(&&T, &str) -> bool;
 
 pub trait SearchableItem {
     fn search_text(&self) -> &str;
+    fn from_search_value(value: &str) -> Self;
 }
 
 pub struct Searchable<T>
@@ -59,7 +60,14 @@ where
             items.sort_by(|a, b| b.1.cmp(&a.1));
         }
 
-        self.filtered = items.into_iter().map(|(item, _)| item).collect();
+        // If no results found, return the search value itself
+        if items.is_empty() {
+            // Create a dummy item with the search value
+            let dummy_item = T::from_search_value(value);
+            self.filtered = vec![dummy_item];
+        } else {
+            self.filtered = items.into_iter().map(|(item, _)| item).collect();
+        }
     }
 
     #[allow(clippy::must_use_candidate)]

--- a/src/searchable.rs
+++ b/src/searchable.rs
@@ -43,30 +43,23 @@ where
             return;
         }
 
-        if self.sort_by_levenshtein {
-            let matcher = SkimMatcherV2::default();
-            let mut items: Vec<_> = self
-                .vec
-                .iter()
-                .filter(|host| (self.filter)(host, value))
-                .map(|item| {
-                    let score = matcher.fuzzy_match(item.search_text(), value).unwrap_or(0);
-                    (item.clone(), score)
-                })
-                .collect();
-
-            // Sort by Levenshtein distance in descending order (higher score = better match)
-            items.sort_by(|a, b| b.1.cmp(&a.1));
-
-            self.filtered = items.into_iter().map(|(item, _)| item).collect();
-        } else {
-            self.filtered = self
+        let matcher = SkimMatcherV2::default();
+        let mut items: Vec<_> = self
             .vec
             .iter()
             .filter(|host| (self.filter)(host, value))
-            .cloned()
+            .map(|item| {
+                let score = matcher.fuzzy_match(item.search_text(), value).unwrap_or(0);
+                (item.clone(), score)
+            })
             .collect();
+
+        // Sort by Levenshtein distance in descending order (higher score = better match)
+        if self.sort_by_levenshtein {
+            items.sort_by(|a, b| b.1.cmp(&a.1));
         }
+
+        self.filtered = items.into_iter().map(|(item, _)| item).collect();
     }
 
     #[allow(clippy::must_use_candidate)]

--- a/src/ssh.rs
+++ b/src/ssh.rs
@@ -6,6 +6,7 @@ use std::collections::VecDeque;
 use std::process::Command;
 
 use crate::ssh_config::{self, parser_error::ParseError, HostVecExt};
+use crate::searchable::SearchableItem;
 
 #[derive(Debug, Serialize, Clone)]
 pub struct Host {
@@ -15,6 +16,12 @@ pub struct Host {
     pub destination: String,
     pub port: Option<String>,
     pub proxy_command: Option<String>,
+}
+
+impl SearchableItem for Host {
+    fn search_text(&self) -> &str {
+        &self.name
+    }
 }
 
 impl Host {

--- a/src/ssh.rs
+++ b/src/ssh.rs
@@ -22,6 +22,17 @@ impl SearchableItem for Host {
     fn search_text(&self) -> &str {
         &self.name
     }
+
+    fn from_search_value(value: &str) -> Self {
+        Host {
+            name: value.to_string(),
+            aliases: String::new(),
+            user: None,
+            destination: String::new(),
+            port: None,
+            proxy_command: None,
+        }
+    }
 }
 
 impl Host {

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -32,6 +32,7 @@ pub struct AppConfig {
 
     pub search_filter: Option<String>,
     pub sort_by_name: bool,
+    pub sort_by_levenshtein: bool,
     pub show_proxy_command: bool,
 
     pub command_template: String,
@@ -103,6 +104,7 @@ impl App {
             palette: tailwind::BLUE,
 
             hosts: Searchable::new(
+                config.sort_by_levenshtein,
                 hosts,
                 &search_input,
                 move |host: &&ssh::Host, search_value: &str| -> bool {


### PR DESCRIPTION
If the search ends up with zero matches, just return the entered text. This mostly solves #139 for me. Real glob parsing would be better, but this works surprisingly well.

I branched this from #140, so it probably will not apply without that PR also applied.