### PR TITLE
#146: Add option to display ProxyJump parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
     <img src="https://repology.org/badge/vertical-allrepos/sshs.svg" alt="Packaging status" align="right">
 </a>
 
-Terminal user interface for SSH.  
+Terminal user interface for SSH.
 It uses `~/.ssh/config` to list and connect to hosts.
 
 <br>
@@ -120,11 +120,17 @@ Host "My server"
   User root
   Port 22
 
-Host "Go through Proxy"
+Host "Go through ProxyCommand"
   HostName server2.example.com
   User someone
   Port 22
   ProxyCommand ssh -W %h:%p proxy.example.com
+
+Host "Go through ProxyJump"
+  HostName server3.example.com
+  User someoneelse
+  Port 22
+  ProxyJump jump.example.com
 ```
 
 You can check the [OpenBSD `ssh_config` reference](https://man.openbsd.org/ssh_config.5) for more information on how to setup `~/.ssh/config`.

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,6 +26,10 @@ struct Args {
     #[arg(long, default_value_t = false)]
     show_proxy_command: bool,
 
+    /// Shows `ProxyJump`
+    #[arg(long, default_value_t = false)]
+    show_proxy_jump: bool,
+
     /// Host search filter
     #[arg(short, long)]
     search: Option<String>,
@@ -64,6 +68,7 @@ fn main() -> Result<()> {
         sort_by_name: args.sort,
         sort_by_levenshtein: args.sort_fancy,
         show_proxy_command: args.show_proxy_command,
+        show_proxy_jump: args.show_proxy_jump,
         command_template: args.template,
         command_template_on_session_start: args.on_session_start_template,
         command_template_on_session_end: args.on_session_end_template,

--- a/src/ssh.rs
+++ b/src/ssh.rs
@@ -16,6 +16,7 @@ pub struct Host {
     pub destination: String,
     pub port: Option<String>,
     pub proxy_command: Option<String>,
+    pub proxy_jump: Option<String>,
 }
 
 impl SearchableItem for Host {
@@ -99,6 +100,7 @@ pub fn parse_config(raw_path: &String) -> Result<Vec<Host>, ParseConfigError> {
                 .unwrap_or_default(),
             port: host.get(&ssh_config::EntryType::Port),
             proxy_command: host.get(&ssh_config::EntryType::ProxyCommand),
+            proxy_jump: host.get(&ssh_config::EntryType::ProxyJump),
         })
         .collect();
 

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -34,6 +34,7 @@ pub struct AppConfig {
     pub sort_by_name: bool,
     pub sort_by_levenshtein: bool,
     pub show_proxy_command: bool,
+    pub show_proxy_jump: bool,
 
     pub command_template: String,
     pub command_template_on_session_start: Option<String>,
@@ -352,7 +353,7 @@ impl App {
         lengths.push(port_len);
 
         if self.config.show_proxy_command {
-            let proxy_len = self
+            let proxy_command_len = self
                 .hosts
                 .non_filtered_iter()
                 .map(|d| match &d.proxy_command {
@@ -362,7 +363,21 @@ impl App {
                 .map(UnicodeWidthStr::width)
                 .max()
                 .unwrap_or(0);
-            lengths.push(proxy_len);
+            lengths.push(proxy_command_len);
+        }
+
+        if self.config.show_proxy_jump {
+            let proxy_jump_len = self
+                .hosts
+                .non_filtered_iter()
+                .map(|d| match &d.proxy_jump {
+                    Some(proxy_jump) => proxy_jump.as_str(),
+                    None => "",
+                })
+                .map(UnicodeWidthStr::width)
+                .max()
+                .unwrap_or(0);
+            lengths.push(proxy_jump_len);
         }
 
         let mut new_constraints = vec![
@@ -453,7 +468,10 @@ fn render_table(f: &mut Frame, app: &mut App, area: Rect) {
 
     let mut header_names = vec!["Name", "Aliases", "User", "Destination", "Port"];
     if app.config.show_proxy_command {
-        header_names.push("Proxy");
+        header_names.push("ProxyCommand");
+    }
+    if app.config.show_proxy_jump {
+        header_names.push("ProxyJump");
     }
 
     let header = header_names
@@ -474,6 +492,9 @@ fn render_table(f: &mut Frame, app: &mut App, area: Rect) {
         ];
         if app.config.show_proxy_command {
             content.push(host.proxy_command.clone().unwrap_or_default());
+        }
+        if app.config.show_proxy_jump {
+            content.push(host.proxy_jump.clone().unwrap_or_default());
         }
 
         content


### PR DESCRIPTION
# Issue

#146

# Description

There is an existing `--show-proxy-command` option. As per [this guide](https://goteleport.com/blog/ssh-proxyjump-ssh-proxycommand/), `ProxyJump` is more popular and recommended over `ProxyCommand`:

> ProxyJump is the easiest and recommended way to jump between hosts because it ensures that traffic passing through the intermediate hosts is always encrypted end-to-end.

This PR adds an option to show `ProxyCommand`:

<img width="589" height="426" alt="image" src="https://github.com/user-attachments/assets/bf96795e-bcd0-4f97-8026-bf7f71539968" />

Example running:
```
cargo run -- --show-proxy-jump --config config-example
```

<img width="1286" height="255" alt="image" src="https://github.com/user-attachments/assets/3a4dcb42-33a8-46de-b923-fe3a1b6c49f4" />
