### PR TITLE
refactor(search): explicitly marking elided lifetimes in iter methods

### DIFF
--- a/src/searchable.rs
+++ b/src/searchable.rs
@@ -72,11 +72,11 @@ where
         self.filtered.is_empty()
     }
 
-    pub fn non_filtered_iter(&self) -> std::slice::Iter<T> {
+    pub fn non_filtered_iter(&self) -> std::slice::Iter<'_, T> {
         self.vec.iter()
     }
 
-    pub fn iter(&self) -> std::slice::Iter<T> {
+    pub fn iter(&self) -> std::slice::Iter<'_, T> {
         self.filtered.iter()
     }
 }


### PR DESCRIPTION
This removes the two warnings `cargo build` emitted:

```
  --> src/searchable.rs:75:30
   |
75 |     pub fn non_filtered_iter(&self) -> std::slice::Iter<T> {
   |                              ^^^^^     ^^^^^^^^^^^^^^^^^^^ the same lifetime is hidden here
   |                              |
   |                              the lifetime is elided here
   |
   = help: the same lifetime is referred to in inconsistent ways, making the signature confusing
   = note: `#[warn(mismatched_lifetime_syntaxes)]` on by default
help: use `'_` for type paths
   |
75 |     pub fn non_filtered_iter(&self) -> std::slice::Iter<'_, T> {
   |                                                         +++

warning: hiding a lifetime that's elided elsewhere is confusing
  --> src/searchable.rs:79:17
   |
79 |     pub fn iter(&self) -> std::slice::Iter<T> {
   |                 ^^^^^     ^^^^^^^^^^^^^^^^^^^ the same lifetime is hidden here
   |                 |
   |                 the lifetime is elided here
   |
   = help: the same lifetime is referred to in inconsistent ways, making the signature confusing
help: use `'_` for type paths
   |
79 |     pub fn iter(&self) -> std::slice::Iter<'_, T> {
   |                                            +++
```

By explicitly marking the elided lifetimes:

```diff
diff --git a/src/searchable.rs b/src/searchable.rs
index 0449dff..8061ccc 100644
--- a/src/searchable.rs
+++ b/src/searchable.rs
@@ -72,11 +72,11 @@ where
         self.filtered.is_empty()
     }

-    pub fn non_filtered_iter(&self) -> std::slice::Iter<T> {
+    pub fn non_filtered_iter(&self) -> std::slice::Iter<'_, T> {
         self.vec.iter()
     }

-    pub fn iter(&self) -> std::slice::Iter<T> {
+    pub fn iter(&self) -> std::slice::Iter<'_, T> {
         self.filtered.iter()
     }
 }
```